### PR TITLE
Did context url

### DIFF
--- a/context/v1/index.jsonld
+++ b/context/v1/index.jsonld
@@ -6,6 +6,7 @@
 		"type": "@type",
 		"did": "https://www.w3.org/ns/did/v1",
 		"schema": "http://schema.org/",
+		"xsd": "http://www.w3.org/2001/XMLSchema#",
 		"Assertion": "https://w3id.org/dcc/v1#Assertion",
 		"zcap": "https://w3id.org/zcap/v1",
 		"dataIntegrity": "https://w3id.org/security/data-integrity/v1",
@@ -25,6 +26,76 @@
 		"token": "https://w3id.org/ixo/protocol/tokens/v1",
 		"vocab": "https://w3id.org/ixo/vocab/v1",
 		"startDate": "http://schema.org/startDate",
-		"endDate": "http://schema.org/endDate"
+		"endDate": "http://schema.org/endDate",
+
+		"CosmosAccountAddress": "https://w3id.org/ixo/protocol/methods/v1#CosmosAccountAddress",
+		"blockchainAccountID": {
+			"@id": "https://w3id.org/ixo/protocol/methods/v1#blockchainAccountID"
+		},
+
+		"linkedResource": {
+			"@id": "https://w3id.org/ixo/protocol/linked-resources/v1#linkedResource",
+			"@container": "@set",
+			"@context": {
+				"id": "@id",
+				"type": "@type",
+				"description": "schema:description",
+				"mediaType": "https://w3id.org/ixo/protocol/linked-resources/v1#mediaType",
+				"serviceEndpoint": { "@id": "https://w3id.org/ixo/protocol/linked-resources/v1#serviceEndpoint", "@type": "@id" },
+				"proof": "https://w3id.org/ixo/protocol/linked-resources/v1#proof",
+				"encrypted": "https://w3id.org/ixo/protocol/linked-resources/v1#encrypted",
+				"right": "https://w3id.org/ixo/protocol/linked-resources/v1#right"
+			}
+		},
+
+		"linkedClaim": {
+			"@id": "https://w3id.org/ixo/protocol/claims/v1#linkedClaim",
+			"@container": "@set",
+			"@context": {
+				"id": "@id",
+				"type": "@type",
+				"description": "schema:description",
+				"mediaType": "https://w3id.org/ixo/protocol/claims/v1#mediaType",
+				"serviceEndpoint": { "@id": "https://w3id.org/ixo/protocol/claims/v1#serviceEndpoint", "@type": "@id" },
+				"proof": "https://w3id.org/ixo/protocol/claims/v1#proof",
+				"encrypted": "https://w3id.org/ixo/protocol/claims/v1#encrypted",
+				"right": "https://w3id.org/ixo/protocol/claims/v1#right"
+			}
+		},
+
+		"linkedEntity": {
+			"@id": "https://w3id.org/ixo/protocol/entities/v1#linkedEntity",
+			"@container": "@set",
+			"@context": {
+				"id": "@id",
+				"type": "@type",
+				"description": "schema:description",
+				"relationship": "https://w3id.org/ixo/protocol/entities/v1#relationship",
+				"service": "https://w3id.org/ixo/protocol/entities/v1#service"
+			}
+		},
+
+		"accordedRight": {
+			"@id": "https://w3id.org/ixo/protocol/accorded-rights/v1#accordedRight",
+			"@container": "@set",
+			"@context": {
+				"id": "@id",
+				"type": "@type",
+				"description": "schema:description",
+				"mediaType": "https://w3id.org/ixo/protocol/accorded-rights/v1#mediaType",
+				"service": "https://w3id.org/ixo/protocol/accorded-rights/v1#service",
+				"serviceEndpoint": { "@id": "https://w3id.org/ixo/protocol/accorded-rights/v1#serviceEndpoint", "@type": "@id" }
+			}
+		},
+
+		"metadata": {
+			"@id": "https://w3id.org/ixo/vocab/v1#metadata",
+			"@context": {
+				"versionId": "https://w3id.org/ixo/vocab/v1#versionId",
+				"created": { "@id": "http://schema.org/dateCreated", "@type": "xsd:dateTime" },
+				"updated": { "@id": "http://schema.org/dateModified", "@type": "xsd:dateTime" },
+				"deactivated": { "@id": "https://w3id.org/ixo/vocab/v1#deactivated", "@type": "xsd:boolean" }
+			}
+		}
 	}
 }

--- a/context/v1/index.jsonld
+++ b/context/v1/index.jsonld
@@ -1,101 +1,104 @@
 {
-	"@context": {
-		"@version": 1.1,
-		"@protected": true,
-		"id": "@id",
-		"type": "@type",
-		"did": "https://www.w3.org/ns/did/v1",
-		"schema": "http://schema.org/",
-		"xsd": "http://www.w3.org/2001/XMLSchema#",
-		"Assertion": "https://w3id.org/dcc/v1#Assertion",
-		"zcap": "https://w3id.org/zcap/v1",
-		"dataIntegrity": "https://w3id.org/security/data-integrity/v1",
-		"verifiableCredential": "https://www.w3.org/2018/credentials/v1",
-		"didixo": "https://w3id.org/ixo/protocol/identifiers/ixo/v1",
-		"didx": "https://w3id.org/ixo/protocol/identifiers/x/v1",
-		"entity": "https://w3id.org/ixo/protocol/entities/v1",
-		"attribute": "https://w3id.org/ixo/protocol/attributes/v1",
-		"claim": "https://w3id.org/ixo/protocol/claims/v1",
-		"right": "https://w3id.org/ixo/protocol/accorded-rights/v1",
-		"credential": "https://w3id.org/ixo/protocol/credentials/v1",
-		"indicator": "https://w3id.org/ixo/protocol/indicators/v1",
-		"identity": "https://w3id.org/ixo/protocol/identity/v1",
-		"resource": "https://w3id.org/ixo/protocol/linked-resources/v1",
-		"payment": "https://w3id.org/ixo/protocol/payments/v1",
-		"method": "https://w3id.org/ixo/protocol/methods/v1",
-		"token": "https://w3id.org/ixo/protocol/tokens/v1",
-		"vocab": "https://w3id.org/ixo/vocab/v1",
-		"startDate": "http://schema.org/startDate",
-		"endDate": "http://schema.org/endDate",
+	"@context": [
+		"https://www.w3.org/ns/did/v1",
+		{
+			"@version": 1.1,
+			"@protected": true,
+			"id": "@id",
+			"type": "@type",
+			"did": "https://www.w3.org/ns/did/v1",
+			"schema": "http://schema.org/",
+			"xsd": "http://www.w3.org/2001/XMLSchema#",
+			"Assertion": "https://w3id.org/dcc/v1#Assertion",
+			"zcap": "https://w3id.org/zcap/v1",
+			"dataIntegrity": "https://w3id.org/security/data-integrity/v1",
+			"verifiableCredential": "https://www.w3.org/2018/credentials/v1",
+			"didixo": "https://w3id.org/ixo/protocol/identifiers/ixo/v1",
+			"didx": "https://w3id.org/ixo/protocol/identifiers/x/v1",
+			"entity": "https://w3id.org/ixo/protocol/entities/v1",
+			"attribute": "https://w3id.org/ixo/protocol/attributes/v1",
+			"claim": "https://w3id.org/ixo/protocol/claims/v1",
+			"right": "https://w3id.org/ixo/protocol/accorded-rights/v1",
+			"credential": "https://w3id.org/ixo/protocol/credentials/v1",
+			"indicator": "https://w3id.org/ixo/protocol/indicators/v1",
+			"identity": "https://w3id.org/ixo/protocol/identity/v1",
+			"resource": "https://w3id.org/ixo/protocol/linked-resources/v1",
+			"payment": "https://w3id.org/ixo/protocol/payments/v1",
+			"method": "https://w3id.org/ixo/protocol/methods/v1",
+			"token": "https://w3id.org/ixo/protocol/tokens/v1",
+			"vocab": "https://w3id.org/ixo/vocab/v1",
+			"startDate": "http://schema.org/startDate",
+			"endDate": "http://schema.org/endDate",
 
-		"CosmosAccountAddress": "https://w3id.org/ixo/protocol/methods/v1#CosmosAccountAddress",
-		"blockchainAccountID": {
-			"@id": "https://w3id.org/ixo/protocol/methods/v1#blockchainAccountID"
-		},
+			"CosmosAccountAddress": "https://w3id.org/ixo/protocol/methods/v1#CosmosAccountAddress",
+			"blockchainAccountID": {
+				"@id": "https://w3id.org/ixo/protocol/methods/v1#blockchainAccountID"
+			},
 
-		"linkedResource": {
-			"@id": "https://w3id.org/ixo/protocol/linked-resources/v1#linkedResource",
-			"@container": "@set",
-			"@context": {
-				"id": "@id",
-				"type": "@type",
-				"description": "schema:description",
-				"mediaType": "https://w3id.org/ixo/protocol/linked-resources/v1#mediaType",
-				"serviceEndpoint": { "@id": "https://w3id.org/ixo/protocol/linked-resources/v1#serviceEndpoint", "@type": "@id" },
-				"proof": "https://w3id.org/ixo/protocol/linked-resources/v1#proof",
-				"encrypted": "https://w3id.org/ixo/protocol/linked-resources/v1#encrypted",
-				"right": "https://w3id.org/ixo/protocol/linked-resources/v1#right"
-			}
-		},
+			"linkedResource": {
+				"@id": "https://w3id.org/ixo/protocol/linked-resources/v1#linkedResource",
+				"@container": "@set",
+				"@context": {
+					"id": "@id",
+					"type": "@type",
+					"description": "schema:description",
+					"mediaType": "https://w3id.org/ixo/protocol/linked-resources/v1#mediaType",
+					"serviceEndpoint": { "@id": "https://w3id.org/ixo/protocol/linked-resources/v1#serviceEndpoint", "@type": "@id" },
+					"proof": "https://w3id.org/ixo/protocol/linked-resources/v1#proof",
+					"encrypted": "https://w3id.org/ixo/protocol/linked-resources/v1#encrypted",
+					"right": "https://w3id.org/ixo/protocol/linked-resources/v1#right"
+				}
+			},
 
-		"linkedClaim": {
-			"@id": "https://w3id.org/ixo/protocol/claims/v1#linkedClaim",
-			"@container": "@set",
-			"@context": {
-				"id": "@id",
-				"type": "@type",
-				"description": "schema:description",
-				"mediaType": "https://w3id.org/ixo/protocol/claims/v1#mediaType",
-				"serviceEndpoint": { "@id": "https://w3id.org/ixo/protocol/claims/v1#serviceEndpoint", "@type": "@id" },
-				"proof": "https://w3id.org/ixo/protocol/claims/v1#proof",
-				"encrypted": "https://w3id.org/ixo/protocol/claims/v1#encrypted",
-				"right": "https://w3id.org/ixo/protocol/claims/v1#right"
-			}
-		},
+			"linkedClaim": {
+				"@id": "https://w3id.org/ixo/protocol/claims/v1#linkedClaim",
+				"@container": "@set",
+				"@context": {
+					"id": "@id",
+					"type": "@type",
+					"description": "schema:description",
+					"mediaType": "https://w3id.org/ixo/protocol/claims/v1#mediaType",
+					"serviceEndpoint": { "@id": "https://w3id.org/ixo/protocol/claims/v1#serviceEndpoint", "@type": "@id" },
+					"proof": "https://w3id.org/ixo/protocol/claims/v1#proof",
+					"encrypted": "https://w3id.org/ixo/protocol/claims/v1#encrypted",
+					"right": "https://w3id.org/ixo/protocol/claims/v1#right"
+				}
+			},
 
-		"linkedEntity": {
-			"@id": "https://w3id.org/ixo/protocol/entities/v1#linkedEntity",
-			"@container": "@set",
-			"@context": {
-				"id": "@id",
-				"type": "@type",
-				"description": "schema:description",
-				"relationship": "https://w3id.org/ixo/protocol/entities/v1#relationship",
-				"service": "https://w3id.org/ixo/protocol/entities/v1#service"
-			}
-		},
+			"linkedEntity": {
+				"@id": "https://w3id.org/ixo/protocol/entities/v1#linkedEntity",
+				"@container": "@set",
+				"@context": {
+					"id": "@id",
+					"type": "@type",
+					"description": "schema:description",
+					"relationship": "https://w3id.org/ixo/protocol/entities/v1#relationship",
+					"service": "https://w3id.org/ixo/protocol/entities/v1#service"
+				}
+			},
 
-		"accordedRight": {
-			"@id": "https://w3id.org/ixo/protocol/accorded-rights/v1#accordedRight",
-			"@container": "@set",
-			"@context": {
-				"id": "@id",
-				"type": "@type",
-				"description": "schema:description",
-				"mediaType": "https://w3id.org/ixo/protocol/accorded-rights/v1#mediaType",
-				"service": "https://w3id.org/ixo/protocol/accorded-rights/v1#service",
-				"serviceEndpoint": { "@id": "https://w3id.org/ixo/protocol/accorded-rights/v1#serviceEndpoint", "@type": "@id" }
-			}
-		},
+			"accordedRight": {
+				"@id": "https://w3id.org/ixo/protocol/accorded-rights/v1#accordedRight",
+				"@container": "@set",
+				"@context": {
+					"id": "@id",
+					"type": "@type",
+					"description": "schema:description",
+					"mediaType": "https://w3id.org/ixo/protocol/accorded-rights/v1#mediaType",
+					"service": "https://w3id.org/ixo/protocol/accorded-rights/v1#service",
+					"serviceEndpoint": { "@id": "https://w3id.org/ixo/protocol/accorded-rights/v1#serviceEndpoint", "@type": "@id" }
+				}
+			},
 
-		"metadata": {
-			"@id": "https://w3id.org/ixo/vocab/v1#metadata",
-			"@context": {
-				"versionId": "https://w3id.org/ixo/vocab/v1#versionId",
-				"created": { "@id": "http://schema.org/dateCreated", "@type": "xsd:dateTime" },
-				"updated": { "@id": "http://schema.org/dateModified", "@type": "xsd:dateTime" },
-				"deactivated": { "@id": "https://w3id.org/ixo/vocab/v1#deactivated", "@type": "xsd:boolean" }
+			"metadata": {
+				"@id": "https://w3id.org/ixo/vocab/v1#metadata",
+				"@context": {
+					"versionId": "https://w3id.org/ixo/vocab/v1#versionId",
+					"created": { "@id": "http://schema.org/dateCreated", "@type": "xsd:dateTime" },
+					"updated": { "@id": "http://schema.org/dateModified", "@type": "xsd:dateTime" },
+					"deactivated": { "@id": "https://w3id.org/ixo/vocab/v1#deactivated", "@type": "xsd:boolean" }
+				}
 			}
 		}
-	}
+	]
 }

--- a/interchain-identifiers/v1/README.md
+++ b/interchain-identifiers/v1/README.md
@@ -1,0 +1,56 @@
+# did:ixo method context — `interchain-identifiers/v1`
+
+JSON-LD context that defines the **method-specific terms** emitted by `did:ixo`
+(Interchain Identifier / IID) documents. These terms are **not** defined by the
+base W3C context `https://www.w3.org/ns/did/v1`, so without this context a
+JSON-LD-aware consumer silently drops them (W3C DID Core
+[§6.3.1 Production](https://www.w3.org/TR/did-core/#production-0): a consumer
+"SHOULD drop all terms … not defined via the `@context`").
+
+| | |
+| --- | --- |
+| **Canonical IRI** | `https://w3id.org/ixo/ns/interchain-identifiers/v1` |
+| **Served document** | `https://ixofoundation.github.io/ns/interchain-identifiers/v1/index.jsonld` |
+| **Media type** | `application/ld+json` |
+
+## Terms defined
+
+- `linkedResource`, `linkedClaim`, `linkedEntity`, `accordedRight` — set-valued
+  IID extension properties, each with a property-scoped `@context` so their
+  nested members (`mediaType`, `serviceEndpoint`, `proof`, `encrypted`, `right`,
+  `description`, …) are also defined and therefore not dropped.
+- `blockchainAccountID` — verification-method account property (CAIP-10 style;
+  note the capital-`ID` casing the method actually emits).
+- `CosmosAccountAddress` — the IID verification-method `type`.
+- `metadata` — document metadata (`versionId`, `created`, `updated`,
+  `deactivated`).
+
+Term IRIs are anchored to the existing IXO protocol/vocab namespaces using the
+repo's per-concept `#fragment` convention.
+
+## How it is used (two changes outside this repo)
+
+1. **Resolver** — append the canonical IRI to the `@context` array of every
+   resolved `did:ixo` document, after the base context:
+
+   ```json
+   "@context": [
+     "https://www.w3.org/ns/did/v1",
+     "https://w3id.org/ixo/ns/interchain-identifiers/v1"
+   ]
+   ```
+
+   Documents are served as `application/did+ld+json`, which asserts the body is
+   JSON-LD — so this array is required for the body to be *conformant* JSON-LD.
+
+2. **DID Specification Registries** — register this context per DID Core §6.3.1
+   ("all JSON-LD Contexts and their terms SHOULD be registered in the DID
+   Specification Registries") via a PR to
+   [`w3c/did-spec-registries`](https://github.com/w3c/did-spec-registries).
+
+## Hosting
+
+The `w3id.org/ixo/.htaccess` rule-0 issues a `303` from the canonical IRI to the
+served document. It is placed **before** the `ns/`-collapse rule so the `ns/`
+segment resolves directly instead of being rewritten to the bare form. Deploy by
+PR to the [w3id.org community repo](https://github.com/perma-id/w3id.org).

--- a/interchain-identifiers/v1/README.md
+++ b/interchain-identifiers/v1/README.md
@@ -28,7 +28,7 @@ JSON-LD-aware consumer silently drops them (W3C DID Core
 Term IRIs are anchored to the existing IXO protocol/vocab namespaces using the
 repo's per-concept `#fragment` convention.
 
-## How it is used (two changes outside this repo)
+## How it is used
 
 1. **Resolver** — append the canonical IRI to the `@context` array of every
    resolved `did:ixo` document, after the base context:

--- a/interchain-identifiers/v1/index.jsonld
+++ b/interchain-identifiers/v1/index.jsonld
@@ -1,0 +1,85 @@
+{
+	"@context": {
+		"@version": 1.1,
+		"@protected": true,
+
+		"ixo": "https://w3id.org/ixo/vocab/v1#",
+		"resources": "https://w3id.org/ixo/protocol/linked-resources/v1#",
+		"claims": "https://w3id.org/ixo/protocol/claims/v1#",
+		"rights": "https://w3id.org/ixo/protocol/accorded-rights/v1#",
+		"entities": "https://w3id.org/ixo/protocol/entities/v1#",
+		"methods": "https://w3id.org/ixo/protocol/methods/v1#",
+		"schema": "http://schema.org/",
+		"xsd": "http://www.w3.org/2001/XMLSchema#",
+
+		"CosmosAccountAddress": "methods:CosmosAccountAddress",
+		"blockchainAccountID": {
+			"@id": "methods:blockchainAccountID"
+		},
+
+		"linkedResource": {
+			"@id": "resources:linkedResource",
+			"@container": "@set",
+			"@context": {
+				"id": "@id",
+				"type": "@type",
+				"description": "schema:description",
+				"mediaType": "resources:mediaType",
+				"serviceEndpoint": { "@id": "resources:serviceEndpoint", "@type": "@id" },
+				"proof": "resources:proof",
+				"encrypted": "resources:encrypted",
+				"right": "resources:right"
+			}
+		},
+
+		"linkedClaim": {
+			"@id": "claims:linkedClaim",
+			"@container": "@set",
+			"@context": {
+				"id": "@id",
+				"type": "@type",
+				"description": "schema:description",
+				"mediaType": "claims:mediaType",
+				"serviceEndpoint": { "@id": "claims:serviceEndpoint", "@type": "@id" },
+				"proof": "claims:proof",
+				"encrypted": "claims:encrypted",
+				"right": "claims:right"
+			}
+		},
+
+		"linkedEntity": {
+			"@id": "entities:linkedEntity",
+			"@container": "@set",
+			"@context": {
+				"id": "@id",
+				"type": "@type",
+				"description": "schema:description",
+				"relationship": "entities:relationship",
+				"service": "entities:service"
+			}
+		},
+
+		"accordedRight": {
+			"@id": "rights:accordedRight",
+			"@container": "@set",
+			"@context": {
+				"id": "@id",
+				"type": "@type",
+				"description": "schema:description",
+				"mediaType": "rights:mediaType",
+				"service": "rights:service",
+				"serviceEndpoint": { "@id": "rights:serviceEndpoint", "@type": "@id" }
+			}
+		},
+
+		"metadata": {
+			"@id": "ixo:metadata",
+			"@context": {
+				"versionId": "ixo:versionId",
+				"created": { "@id": "schema:dateCreated", "@type": "xsd:dateTime" },
+				"updated": { "@id": "schema:dateModified", "@type": "xsd:dateTime" },
+				"deactivated": { "@id": "ixo:deactivated", "@type": "xsd:boolean" }
+			}
+		}
+	}
+}


### PR DESCRIPTION
 Add did:ixo method JSON-LD context and make resolved documents 
  conformant JSON-LD

  Summary

  did:ixo documents are served as application/did+ld+json —       
  asserting they are JSON-LD — but emit method-specific terms that
  the base W3C context (https://www.w3.org/ns/did/v1) does not
  define: linkedResource, linkedClaim, linkedEntity, accordedRight
  (and their nested members), blockchainAccountID, the
  CosmosAccountAddress verification-method type, and metadata. Per
  W3C DID Core §6.3.1
  (https://www.w3.org/TR/did-core/#production-0), a conforming    
  consumer drops every term not defined via @context — so any     
  JSON-LD/RDF processor, VC library, or Universal Resolver client 
  silently discards the entire IXO extension surface.

  This PR adds the missing JSON-LD context so those terms survive.

  Changes

  - New method context — interchain-identifiers/v1/index.jsonld (+
  README.md). JSON-LD 1.1, @protected. Defines all did:ixo method 
  terms; linkedResource/linkedClaim/linkedEntity/accordedRight    
  are @set-valued with property-scoped @contexts so their nested  
  members (mediaType, serviceEndpoint, proof, encrypted, right,   
  description, …) are also defined. Term IRIs anchor to the       
  existing IXO protocol/vocab namespaces using the repo's
  per-concept #fragment convention. Canonical IRI:
  https://w3id.org/ixo/ns/interchain-identifiers/v1.
  - Umbrella context/v1 — folds the same term definitions in,     
  since the stored corpus documents reference the umbrella        
  directly rather than the W3C base context.
  - Umbrella imports did/v1 — the umbrella declared "did" only as 
  a prefix mapping, which does not import that context's terms, so
  umbrella-only documents were still dropping the DID-core        
  properties (controller, verificationMethod, authentication,     
  alsoKnownAs, …). The umbrella's top-level @context is now an    
  array beginning with https://www.w3.org/ns/did/v1, so
  umbrella-only documents resolve both the DID-core and IXO terms.

  Verification

  Expanded a representative did:ixo document with jsonld@9 in both
  consumer patterns:

  - Umbrella-only (@context: "https://w3id.org/ixo/context/v1" —  
  the corpus pattern): PASS, no terms dropped.
  - Resolver output (["…/did/v1", "…/interchain-identifiers/v1"]):
  PASS, no terms dropped.

  All predicates resolve to absolute IRIs after expansion
  (DID-core → w3id.org/security#… / activitystreams#…; IXO →      
  w3id.org/ixo/…), with no @protected redefinition conflict from  
  the scoped serviceEndpoint.

  Out of scope / follow-ups

  - w3id redirect — a 303 from …/ixo/ns/interchain-identifiers/v1 
  to the served document, placed before the ns/-collapse rule.    
  Lives in the separate w3id.org config repo.
  - Resolver — append
  https://w3id.org/ixo/ns/interchain-identifiers/v1 to the        
  @context array it returns (one line).
  - DID Spec Registries — register the context per §6.3.1.   